### PR TITLE
chore: fix lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Builds, tests & co
+name: Actions
 
 on:
   push:
@@ -44,17 +44,6 @@ jobs:
       - run: opam exec -- dune build
 
       - run: opam exec -- dune runtest
-
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: _build/default/world.exe
-
-      - name: Upload the build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.os }}-${{ matrix.ocaml-compiler }}-world.exe
-          path: _build/default/bin/fluido_cli.exe
 
   lint-doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-${{ matrix.ocaml-compiler }}-world.exe
-          path: _build/default/world.exe
+          path: _build/default/bin/fluido_cli.exe
 
   lint-doc:
     runs-on: ubuntu-latest

--- a/dune-project
+++ b/dune-project
@@ -3,6 +3,8 @@
 (name fluido)
 (generate_opam_files true)
 (license MIT)
+(authors kayagokalp)
+(maintainers ["kayagokalp"])
 (source (github kayagokalp/fluidoml))
 
 (package

--- a/dune-project
+++ b/dune-project
@@ -1,15 +1,23 @@
 (lang dune 3.0)
 
 (name fluido)
+
 (generate_opam_files true)
+
 (license MIT)
+
 (authors kayagokalp)
-(maintainers ["kayagokalp"])
-(source (github kayagokalp/fluidoml))
+
+(maintainers [ kayagokalp ])
+
+(source
+ (github kayagokalp/fluidoml))
 
 (package
  (name fluido)
  (synopsis "Fluido core package")
- (description "A project for simulating fluid mixing experiments, including a command-line interface.")
- (depends cmdliner alcotest))
-
+ (description
+  "A project for simulating fluid mixing experiments, including a command-line interface.")
+ (depends
+  cmdliner
+  (alcotest :with-test)))

--- a/fluido.opam
+++ b/fluido.opam
@@ -3,6 +3,8 @@ opam-version: "2.0"
 synopsis: "Fluido core package"
 description:
   "A project for simulating fluid mixing experiments, including a command-line interface."
+maintainer: ["[" "kayagokalp" "]"]
+authors: ["kayagokalp"]
 license: "MIT"
 homepage: "https://github.com/kayagokalp/fluidoml"
 bug-reports: "https://github.com/kayagokalp/fluidoml/issues"

--- a/fluido.opam
+++ b/fluido.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/kayagokalp/fluidoml/issues"
 depends: [
   "dune" {>= "3.0"}
   "cmdliner"
-  "alcotest"
+  "alcotest" {with-test}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Fixes lints by adding required metadata to `dune-project` field and also correcting the path of binary.